### PR TITLE
Update .gitignore and stop tracking .vscode in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ci-server/target/
 .vscode
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ci-server/target/
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "automatic"
-}


### PR DESCRIPTION
I think it'll be easier in the long run if we just ignore the .vscode files. It seems as if as long as git tracks the settings.json file, any changes to it will always be detected, even if git is supposed to ignore such files. Thus it will be very annoying to have any separate settings for vscode.

I suggest one personally can add "java.configuration.updateBuildConfiguration": "automatic" to one's settings.json file in .vscode if one want to. VS code should also do this automatically if you click "always" in the message that comes up after vscode detects a change to the pom.xml file.