### PR TITLE
Add design for commit page

### DIFF
--- a/status-site/src/components/CommitCard.astro
+++ b/status-site/src/components/CommitCard.astro
@@ -48,17 +48,7 @@ const { commit } = Astro.props
 </div>
 
 <style>
-  a {
-    color: #2F4566;
-  }
-  a:hover {
-    color: #486a9d;
-  }
-  p {
-    display: inline;
-    font-size: 1rem;
-    margin: 0;
-  }
+
   .card-header {
     display: flex;
     flex-direction: row;
@@ -122,19 +112,11 @@ const { commit } = Astro.props
     border-radius: 50%;
     margin-right: 0.5rem;
   }
-  .build-info {
-    margin: 1rem;
-    margin: 0;
-  }
+
   .authortext {
     margin-right: 2rem;
   }
-  .success {
-    color: var(--green);
-  }
-  .fail {
-    color: var(--red);
-  }
+  
   .link-image {
     width: 1rem;
     height: 1rem;

--- a/status-site/src/layouts/Layout.astro
+++ b/status-site/src/layouts/Layout.astro
@@ -1,38 +1,68 @@
 ---
 export interface Props {
-	title: string;
+  title: string
 }
 
-const { title } = Astro.props;
+const { title } = Astro.props
 ---
 
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="generator" content={Astro.generator} />
-		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,500,0,0" />
-		<title>{title}</title>
-	</head>
-	<body>
-		<slot />
-	</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="generator" content={Astro.generator} />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,500,0,0"
+    />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
 </html>
 <style is:global>
-	:root {
-		--accent: 124, 58, 237;
-		--accent-gradient: linear-gradient(45deg, rgb(var(--accent)), #da62c4 30%, white 60%);
-		--red: #EE4E4E;
-		--green: #4FBD45;
-	}
-	html {
-		font-family: system-ui, sans-serif;
-		background-color: #F6F6F6;
-	}
-	code {
-		font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
-			Bitstream Vera Sans Mono, Courier New, monospace;
-	}
+  :root {
+    --accent: 124, 58, 237;
+    --accent-gradient: linear-gradient(
+      45deg,
+      rgb(var(--accent)),
+      #da62c4 30%,
+      white 60%
+    );
+    --red: #ee4e4e;
+    --green: #4fbd45;
+  }
+  html {
+    font-family: system-ui, sans-serif;
+    background-color: #f6f6f6;
+  }
+  code {
+    font-family: Menlo, Monaco, Lucida Console, Liberation Mono,
+      DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
+  }
+  a {
+    color: #2f4566;
+  }
+  a:hover {
+    color: #486a9d;
+  }
+  p {
+    display: inline;
+    font-size: 1rem;
+    margin: 0;
+  }
+
+  .success {
+    color: var(--green);
+  }
+  .fail {
+    color: var(--red);
+  }
+  .build-info {
+    margin: 1rem;
+    margin: 0;
+  }
 </style>

--- a/status-site/src/logic/fetch_commit.ts
+++ b/status-site/src/logic/fetch_commit.ts
@@ -23,6 +23,7 @@ export async function fetchCommits(
     const bareCommit = bareCommits.find(
       (bareCommit) => bareCommit.sha === commit.sha
     )
+    console.log(bareCommit?.log)
     return {
       ...commit,
       status: bareCommit?.status ?? "unset",

--- a/status-site/src/logic/fetch_commit.ts
+++ b/status-site/src/logic/fetch_commit.ts
@@ -23,7 +23,6 @@ export async function fetchCommits(
     const bareCommit = bareCommits.find(
       (bareCommit) => bareCommit.sha === commit.sha
     )
-    console.log(bareCommit?.log)
     return {
       ...commit,
       status: bareCommit?.status ?? "unset",

--- a/status-site/src/logic/fetch_commit.ts
+++ b/status-site/src/logic/fetch_commit.ts
@@ -24,9 +24,9 @@ export async function fetchCommits(
       (bareCommit) => bareCommit.sha === commit.sha
     )
     return {
-        ...commit,
-        status: bareCommit?.status ?? "unset",
-        log: bareCommit?.log,
+      ...commit,
+      status: bareCommit?.status ?? "unset",
+      log: bareCommit?.log,
     } as ExtendedCommit
   })
 }

--- a/status-site/src/pages/[commit].astro
+++ b/status-site/src/pages/[commit].astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import { BareCommit, fetchCommits } from "../logic/fetch_commit";
 import { commits as bareCommits } from "../../../data.json";
 import type { ExtendedCommit } from "../logic/github.commit.types";
+import { DateTime } from "luxon";
 
 export async function getStaticPaths() {
 	const commits = await fetchCommits(bareCommits as BareCommit[])
@@ -16,12 +17,92 @@ export async function getStaticPaths() {
 	}))
 }
 
-const item = Astro.props.item as ExtendedCommit;
-
+const commit = Astro.props.item as ExtendedCommit;
+console.log(commit.log)
 ---
 
-<Layout title={item.commit.message}>
-	<p>You are viewing commit: {item.sha}</p>
-	<p>Status: {item.status}</p>
-	<p>Author: {item.commit.author?.name}</p>
+<Layout title={commit.commit.message}>
+	<div class="page-container">
+		<div class="header-row">
+			<h3>{commit.commit.message.split("\n")[0]}</h3>
+			{
+				commit.status === "unset" ? null : commit.status === "success" ? (
+				  <p class="build-info success">Build passed</p>
+				) : (
+				  <p class="build-info fail">Build failed</p>
+				)
+			  }
+		</div>
+		<div class="commit-description-container">
+			{commit.commit.message.split("\n").length > 1 ? 
+				<>{commit.commit.message.split("\n").slice(1).filter(current => current.length != 0).map(current => <p>{current}</p>)}</> : 
+				null
+			}
+		</div>
+		<div class="metarow">
+			{commit.commit.author?.date != null ? <p class="datetext card-header-text">{DateTime.fromISO(commit.commit.author?.date).toFormat("HH:mm, d MMMM yyyy")}</p> : null}
+			<div>
+				<img class="author-image" src={commit.author?.avatar_url} />
+   		        <a href={`https://github.com/${commit.commit.author?.name}`} class="authortext">{commit.commit.author?.name}</a>
+			</div>
+			<p>{commit.sha}</p>
+		</div>
+		<div class="log-container">
+		{commit.log != null ? 
+			commit.log?.split("\n").map((line) => <p class="log-row">{line}</p>) : 
+			<p>This commit has not been processed by the CI server</p>}
+		</div>
+		
+	</div>
 </Layout>
+
+<style>
+	.header-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+	.page-container {
+		display: flex;
+		flex-direction: column;
+		
+		max-width: 800px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.commit-description-container {
+		margin-bottom: 2rem;
+	}
+	.commit-description-container p {
+		display: block;
+		color: #777;
+	}
+
+	.metarow {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+	.metarow p {
+		color: #777;
+	}
+	.author-image {
+		margin-right: 0.5rem;
+		height: 1rem;
+		border-radius: 50%;
+	}
+	.log-container {
+		margin-top: 1rem;
+		border-radius: 10px;
+		background-color: #1E2836;
+		padding: 1rem;
+		color: #ccc;
+	}
+	.log-row {
+		display: block;
+		margin-bottom: 0.75rem;
+	}
+</style>

--- a/status-site/src/pages/[commit].astro
+++ b/status-site/src/pages/[commit].astro
@@ -45,7 +45,7 @@ console.log(commit.log)
 				<img class="author-image" src={commit.author?.avatar_url} />
    		        <a href={`https://github.com/${commit.commit.author?.name}`} class="authortext">{commit.commit.author?.name}</a>
 			</div>
-			<p>{commit.sha}</p>
+			<a href={commit.html_url}>{commit.sha}</a>
 		</div>
 		<div class="log-container">
 		{commit.log != null ? 

--- a/status-site/src/pages/[commit].astro
+++ b/status-site/src/pages/[commit].astro
@@ -18,7 +18,6 @@ export async function getStaticPaths() {
 }
 
 const commit = Astro.props.item as ExtendedCommit;
-console.log(commit.log)
 ---
 
 <Layout title={commit.commit.message}>


### PR DESCRIPTION
Commit page now has an ok design and provides all the content for each commit

![image](https://user-images.githubusercontent.com/30767818/217323285-deaddf7d-4fa2-491a-a7b0-e306ddd877e7.png)
