### PR TITLE
Make ci-website fetch assessment branch

### DIFF
--- a/status-site/src/logic/fetch_commit.ts
+++ b/status-site/src/logic/fetch_commit.ts
@@ -11,7 +11,7 @@ export async function fetchCommits(
   bareCommits: BareCommit[]
 ): Promise<ExtendedCommit[]> {
   const commits = await axios.get<Commit[]>(
-    `https://api.github.com/repos/kth-cdate-courses/DD2480-CI/commits`
+    `https://api.github.com/repos/kth-cdate-courses/DD2480-CI/commits?sha=assessment`
   )
   // Only include commits that we have processed
   return commits.data.map((commit) => {


### PR DESCRIPTION
Now the assessment branch will be displayed on the ci-website.

Co-Authored-By: EdwardNorberg <61504186+EdwardNorberg@users.noreply.github.com>
Co-Authored-By: Hampus Hallkvist <30767818+Hampfh@users.noreply.github.com>