### PR TITLE
fix: no MalformedUrlException thrown #72

### DIFF
--- a/ci-server/src/test/java/com/group1/ContinuousIntegrationServerTest.java
+++ b/ci-server/src/test/java/com/group1/ContinuousIntegrationServerTest.java
@@ -57,7 +57,7 @@ public class ContinuousIntegrationServerTest
      * @throws DownloadFailedException
      */
     @Test
-    public void repositoryNotEmptyCloningTest() throws DownloadFailedException, MalformedURLException {
+    public void repositoryNotEmptyCloningTest() throws DownloadFailedException {
         String repoUrl = "https://github.com/kth-cdate-courses/DD2480-CI.git";
         File repoDirectory = new File("./watched-repository");
 


### PR DESCRIPTION
The unit test for repositoryNotEmptyCloningTest does not throw MalformedUrlException anymore.