### PR TITLE
Ignore error file for deployment script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ci-server/target/
 *.DS_Store
 ci-server/watched-repository
 ci-server/testResultOutput
+builder_error_file


### PR DESCRIPTION
The file being created, that should be ignored, is called builder_error_file.