### PR TITLE
Make sure the deployment script is found

### DIFF
--- a/ci-server/src/main/java/com/group1/ContinuousIntegrationServer.java
+++ b/ci-server/src/main/java/com/group1/ContinuousIntegrationServer.java
@@ -86,6 +86,9 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         String deployArgs = HEADcommitSHA + " " + testStatus.toString() + " " + "'" + getLogs(testResultsOutputFile) + "'";
         ProcessBuilder processBuilder = new ProcessBuilder("bash", "-c", "deploy.sh " + deployArgs);
         processBuilder.redirectError(new File("builder_error_file"));
+        // secure relative pathing to deploy.sh file
+        if (!(new File("ci-server").exists()))
+            processBuilder.directory(new File("../"));
         processBuilder.start();
         System.out.println("handle done, deploying site");
     }


### PR DESCRIPTION
Depending on how the application is started the default relative path may be different.